### PR TITLE
Enhancement to setNumTXBoxes()

### DIFF
--- a/due_can.h
+++ b/due_can.h
@@ -223,7 +223,7 @@ class CANRaw
 	int watchFor(uint32_t id, uint32_t mask); //allow a range of ids through
 	int watchForRange(uint32_t id1, uint32_t id2); //try to allow the range from id1 to id2 - automatically determine base ID and mask
 
-	void setNumTXBoxes(int txboxes);
+	int setNumTXBoxes(int txboxes);
 	int findFreeRXMailbox();
 	uint8_t mailbox_get_mode(uint8_t uc_index);
 	uint32_t mailbox_get_id(uint8_t uc_index);


### PR DESCRIPTION
Alter setNumTXBoxes() to return the actual number of Tx boxes that were set.  Allows for application to discover the physical quantity of hardware mailboxes, ala:

  int MB_Qty = setNumTXBoxes(999);                               // How many Mailboxes are there?
      setNumTXBoxes(MB_qty/2);                                       // Configure 1/2 of them as Tx boxes, we can use the rest for Rx filtering.
   . . . . . .



Then the application can recall setNumTXBoxes() with the actual desired quantity.  As this change is from void to int, it should cause no issues with existing applications.