### PR TITLE
Enhancement to setNumTXBoxes()

### DIFF
--- a/due_can.cpp
+++ b/due_can.cpp
@@ -210,8 +210,10 @@ uint32_t CANRaw::init(uint32_t ul_baudrate)
  *
  * \param txboxes How many of the 8 boxes should be used for TX
  *
+ * \retval number of tx boxes set.
+ *
  */
-void CANRaw::setNumTXBoxes(int txboxes) {
+int CANRaw::setNumTXBoxes(int txboxes) {
 	int c;
 
 	if (txboxes > 8) txboxes = 8;
@@ -231,6 +233,8 @@ void CANRaw::setNumTXBoxes(int txboxes) {
 		mailbox_set_priority(c, 10);
 		mailbox_set_accept_mask(c, 0x7FF, false);
 	}
+	
+	return (numTXBoxes);
 }
 
 /**


### PR DESCRIPTION
Alter setNumTXBoxes() to return the actual number of Tx boxes that were set.  Allows for application to discover the physical quantity of hardware mailboxes, ala:

  int MB_Qty = setNumTXBoxes(999);                               // How many Mailboxes are there?
      setNumTXBoxes(MB_qty/2);                                       // Configure 1/2 of them as Tx boxes, we can use the rest for Rx filtering.
   . . . . . .



Then the application can recall setNumTXBoxes() with the actual desired quantity.  As this change is from void to int, it should cause no issues with existing applications.