### PR TITLE
 Proposed change: Adding timestamping to received mssgs 

### DIFF
--- a/due_can.cpp
+++ b/due_can.cpp
@@ -506,7 +506,7 @@ uint32_t CANRaw::get_status()
  *
  * \retval The internal CAN free-running timer counter.
  */
-uint32_t CANRaw::get_internal_timer_value()
+uint16_t CANRaw::get_internal_timer_value()
 {
 	return (m_pCan->CAN_TIM);
 }
@@ -517,7 +517,7 @@ uint32_t CANRaw::get_internal_timer_value()
  *
  * \retval The timestamp value.
  */
-uint32_t CANRaw::get_timestamp_value()
+uint16_t CANRaw::get_timestamp_value()
 {
 	return (m_pCan->CAN_TIMESTP);
 }

--- a/due_can.cpp
+++ b/due_can.cpp
@@ -780,7 +780,8 @@ uint32_t CANRaw::mailbox_read(uint8_t uc_index, volatile CAN_FRAME *rxframe)
 	}
 	rxframe->fid = m_pCan->CAN_MB[uc_index].CAN_MFID;
 	rxframe->length = (ul_status & CAN_MSR_MDLC_Msk) >> CAN_MSR_MDLC_Pos;
-	ul_datal = m_pCan->CAN_MB[uc_index].CAN_MDL;
+    rxframe->time   = (ul_status & CAN_MSR_MTIMESTAMP_Msk);
+    ul_datal = m_pCan->CAN_MB[uc_index].CAN_MDL;
 	ul_datah = m_pCan->CAN_MB[uc_index].CAN_MDH;
 
 	rxframe->data.high = ul_datah;
@@ -1032,6 +1033,7 @@ uint32_t CANRaw::get_rx_buff(CAN_FRAME& buffer) {
 	buffer.id = rx_frame_buff[rx_buffer_tail].id;
 	buffer.extended = rx_frame_buff[rx_buffer_tail].extended;
 	buffer.length = rx_frame_buff[rx_buffer_tail].length;
+	buffer.time   = rx_frame_buff[rx_buffer_tail].time;
 	buffer.data.value = rx_frame_buff[rx_buffer_tail].data.value;
 	rx_buffer_tail = (rx_buffer_tail + 1) % SIZE_RX_BUFFER;
 	return 1;

--- a/due_can.h
+++ b/due_can.h
@@ -164,6 +164,7 @@ typedef struct
 	uint8_t rtr;		// Remote Transmission Request
 	uint8_t priority;	// Priority but only important for TX frames and then only for special uses.
 	uint8_t extended;	// Extended ID flag
+    uint16_t time;      // CAN timer value when mailbox message was received.
 	uint8_t length;		// Number of data bytes
 	BytesUnion data;	// 64 bits - lots of ways to access it.
 } CAN_FRAME;

--- a/due_can.h
+++ b/due_can.h
@@ -284,8 +284,8 @@ class CANRaw
 	void disable_interrupt(uint32_t dw_mask);
 	uint32_t get_interrupt_mask();
 	uint32_t get_status();
-	uint32_t get_internal_timer_value();
-	uint32_t get_timestamp_value();
+	uint16_t get_internal_timer_value();
+	uint16_t get_timestamp_value();
 	uint8_t get_tx_error_cnt();
 	uint8_t get_rx_error_cnt();
 	void reset_internal_timer();


### PR DESCRIPTION
Proposing to add additional value to CANFRAME structure:  .time
(timestamp).  Allows applications to  apply aging decisions to received
messages.
